### PR TITLE
tag example

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -62,6 +62,8 @@ void send_event(void)
     sentry_value_set_by_key(event, "message", sentry_value_new_string("Sentry Message Capture"));
     sentry_value_set_by_key(event, "contexts", contexts);
 
+    sentry_set_tag("key_name", "value");
+
     sentry_capture_event(event);
 }
 

--- a/src/example.c
+++ b/src/example.c
@@ -29,6 +29,8 @@ void startup(void)
     sentry_value_set_by_key(user, "username", sentry_value_new_string("John Doe"));
     sentry_set_user(user);
 
+    sentry_set_tag("sessionState", "crashed");
+
     initialize_memory((char *)0x0);
 
     sentry_add_breadcrumb(sentry_value_new_breadcrumb(0, "Finished setup"));


### PR DESCRIPTION
because we didn't have one.

we only had setting new 'contexts' object which are similar.

Tags are very reportable.