### PR TITLE
[WIP] Instrument performance for demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=sentry-native
+SENTRY_PROJECT=native
 VERSION ?= $(shell sentry-cli releases propose-version)
 CMAKE=cmake
 
@@ -41,13 +41,13 @@ upload_debug_files:
 	sentry-cli upload-dif --org testorg-az --project $(SENTRY_PROJECT) --wait --include-sources bin/
 
 run_crash:
-	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example --crash
+	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@o87286.ingest.sentry.io/1720457 bin/example --crash
 
 run_message:
-	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example --message
+	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@o87286.ingest.sentry.io/1720457 bin/example --message
 
 run_clean:
-	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example
+	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@o87286.ingest.sentry.io/1720457 bin/example
 
 clean:
 	rm -rf ./bin/exampl*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=native
+SENTRY_PROJECT=chris-danny-native-testing
 VERSION ?= $(shell sentry-cli releases propose-version)
 CMAKE=cmake
 
@@ -7,7 +7,7 @@ all: bin/example
 .PHONY: all prereqs sentry-makefile sentry-makefile setup_release create_release associate_commits upload_debug_files run_crash run_message clean clean_db
 
 bin/example: prereqs src/example.c
-	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
+	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
 
 prereqs: bin/libsentry.dylib bin/crashpad_handler
 
@@ -39,13 +39,13 @@ upload_debug_files:
 	sentry-cli upload-dif --org testorg-az --project $(SENTRY_PROJECT) --wait --include-sources bin/
 
 run_crash:
-	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@sentry.io/1720457 bin/example --crash
+	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example --crash
 
 run_message:
-	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@sentry.io/1720457 bin/example --message
+	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example --message
 
 run_clean:
-	SENTRY_DSN=https://b5ceabee4e4a4cd6b21afe3bd2cbbed4@sentry.io/1720457 bin/example
+	SENTRY_DSN=https://35a178f3e42445ada24add8bca35a226@o87286.ingest.sentry.io/6297711 bin/example
 
 clean:
 	rm -rf ./bin/exampl*

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,7 @@
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=chris-danny-native-testing
+SENTRY_PROJECT=sentry-native
 VERSION ?= $(shell sentry-cli releases propose-version)
 CMAKE=cmake
-
-# This should point to a directory that holds libcurl, if it isn't
-# in the system's standard lib dir
-# We also set a -L to include the directory where we have the openssl
-# libraries
-LDFLAGS = -L/home/dast/lib -L/usr/local/ssl/lib
-
-# We need -lcurl for the curl stuff
-# We need -lsocket and -lnsl when on Solaris
-# We need -lssl and -lcrypto when using libcurl with SSL support
-# We need -lpthread for the pthread example
-LIBS = -lcurl -lsocket -lnsl -lssl -lcrypto
 
 all: bin/example
 .PHONY: all prereqs sentry-makefile sentry-makefile setup_release create_release associate_commits upload_debug_files run_crash run_message clean clean_db

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ CMAKE=cmake
 all: bin/example
 .PHONY: all prereqs sentry-makefile sentry-makefile setup_release create_release associate_commits upload_debug_files run_crash run_message clean clean_db
 
+# add the following flags if you want to enable the real api call: -lcurl -mmacosx-version-min=10.6
+# note that including `-lcurl` flag will require you to download libcurl locally and set that up.
 bin/example: prereqs src/example.c
-	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -lcurl -mmacosx-version-min=10.6 -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
+	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
 
 prereqs: bin/libsentry.dylib bin/crashpad_handler
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=sentry-native
+SENTRY_PROJECT=native
 VERSION ?= $(shell sentry-cli releases propose-version)
 CMAKE=cmake
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: bin/example
 .PHONY: all prereqs sentry-makefile sentry-makefile setup_release create_release associate_commits upload_debug_files run_crash run_message clean clean_db
 
 bin/example: prereqs src/example.c
-	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -lcurl -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
+	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -lcurl -mmacosx-version-min=10.6 -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
 
 prereqs: bin/libsentry.dylib bin/crashpad_handler
 

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,23 @@ SENTRY_PROJECT=chris-danny-native-testing
 VERSION ?= $(shell sentry-cli releases propose-version)
 CMAKE=cmake
 
+# This should point to a directory that holds libcurl, if it isn't
+# in the system's standard lib dir
+# We also set a -L to include the directory where we have the openssl
+# libraries
+LDFLAGS = -L/home/dast/lib -L/usr/local/ssl/lib
+
+# We need -lcurl for the curl stuff
+# We need -lsocket and -lnsl when on Solaris
+# We need -lssl and -lcrypto when using libcurl with SSL support
+# We need -lpthread for the pthread example
+LIBS = -lcurl -lsocket -lnsl -lssl -lcrypto
+
 all: bin/example
 .PHONY: all prereqs sentry-makefile sentry-makefile setup_release create_release associate_commits upload_debug_files run_crash run_message clean clean_db
 
 bin/example: prereqs src/example.c
-	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
+	$(CC) -g -o $@ -DSENTRY_RELEASE=\"$(VERSION)\" -DSENTRY_PERFORMANCE_MONITORING="ON" -lcurl -Isentry-native/include src/example.c -Lbin -lsentry -Wl,-rpath,"@executable_path"
 
 prereqs: bin/libsentry.dylib bin/crashpad_handler
 

--- a/src/example.c
+++ b/src/example.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include "sentry.h"
 // /bin has crashpad binary executables
 

--- a/src/example.c
+++ b/src/example.c
@@ -18,7 +18,7 @@ void initialize_memory(char *mem)
 
 void startup(void)
 {
-    sentry_set_transaction("startup");
+    // sentry_set_transaction("startup");
     sentry_set_level(SENTRY_LEVEL_ERROR);
 
     sentry_add_breadcrumb(sentry_value_new_breadcrumb(0, "Setting user to John Doe"));
@@ -38,7 +38,7 @@ void startup(void)
 
 void send_event(void)
 {
-    sentry_set_transaction("send_event");
+    // sentry_set_transaction("send_event");
 
     sentry_add_breadcrumb(sentry_value_new_breadcrumb(0, "Configuring GPU Context"));
 
@@ -90,37 +90,61 @@ int main(int argc, char *argv[])
 
     sentry_init(options);
 
-    // Trigger transactions
-    sentry_transaction_context_t *tx_ctx
-        = sentry_transaction_context_new("little.teapot",
-            "Short and stout here is my handle and here is my spout");
+    // Transactions can be started by providing the name and the operation
+    sentry_transaction_context_t *tx_ctx = sentry_transaction_context_new(
+        "transaction name", 
+        "transaction operation"
+    );
+    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
-    sentry_transaction_context_set_sampled(tx_ctx, 0);
-
-    sentry_transaction_t *tx
-        = sentry_transaction_start(tx_ctx, sentry_value_new_null());
-
+    // Transactions can have child spans (and those spans can have child spans as well)
+    sentry_span_t *span = sentry_transaction_start_child(
+        tx, 
+        "child operation", 
+        "child description"
+    );
     printf("CHRIS2");
-    sentry_transaction_set_status(
-        tx, SENTRY_SPAN_STATUS_INTERNAL_ERROR);
 
-    sentry_span_t *child
-        = sentry_transaction_start_child(tx, "littler.teapot", NULL);
-    sentry_span_t *grandchild
-        = sentry_span_start_child(child, "littlest.teapot", NULL);
+    // ...
+    // (Perform the operation represented by the span/transaction)
+    // ...
+
+    sentry_span_finish(span); // Mark the span as finished
+    sentry_transaction_finish(tx); // Mark the transaction as finished and send 
+
     printf("CHRIS3");
 
-    sentry_span_set_status(child, SENTRY_SPAN_STATUS_NOT_FOUND);
-    sentry_span_set_status(
-        grandchild, SENTRY_SPAN_STATUS_ALREADY_EXISTS);
+    // // Trigger transactions
+    // sentry_transaction_context_t *tx_ctx
+    //     = sentry_transaction_context_new("little.teapot",
+    //         "Short and stout here is my handle and here is my spout");
 
-    sentry_span_finish(grandchild);
-    sentry_span_finish(child);
+    // sentry_transaction_context_set_sampled(tx_ctx, 0);
 
-    sentry_transaction_finish(tx);
-    printf("CHRIS4");
+    // sentry_transaction_t *tx
+    //     = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
-    // End instrument performance
+    // printf("CHRIS2");
+    // sentry_transaction_set_status(
+    //     tx, SENTRY_SPAN_STATUS_INTERNAL_ERROR);
+
+    // sentry_span_t *child
+    //     = sentry_transaction_start_child(tx, "littler.teapot", NULL);
+    // sentry_span_t *grandchild
+    //     = sentry_span_start_child(child, "littlest.teapot", NULL);
+    // printf("CHRIS3");
+
+    // sentry_span_set_status(child, SENTRY_SPAN_STATUS_NOT_FOUND);
+    // sentry_span_set_status(
+    //     grandchild, SENTRY_SPAN_STATUS_ALREADY_EXISTS);
+
+    // sentry_span_finish(grandchild);
+    // sentry_span_finish(child);
+
+    // sentry_transaction_finish(tx);
+    // printf("CHRIS4");
+
+    // // End instrument performance
 
     // Native Crash else do a Sentry Message
     if (argc != 2) {

--- a/src/example.c
+++ b/src/example.c
@@ -18,21 +18,21 @@ void initialize_memory(char *mem)
     memset(mem, 1, 100);
 }
 
-void api_call(void)
-{
-    // struct curl_slist *chunk = NULL;
-    // chunk = curl_slist_append(chunk, "sentry-trace: "); //Need to retrieve and interpolate the current trace-id?
+// void api_call(void)
+// {
+//     // struct curl_slist *chunk = NULL;
+//     // chunk = curl_slist_append(chunk, "sentry-trace: "); //Need to retrieve and interpolate the current trace-id?
 
-    printf("CHRIS api call");
-    CURL *curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_URL, 
-        "https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products");
-    curl_easy_perform(curl);
-    sentry_value_t request = sentry_value_new_object();
-    sentry_value_set_by_key(request, "url", sentry_value_new_string("https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products"));
-    sentry_value_set_by_key(request, "method", sentry_value_new_string("GET"));
-    sentry_set_context("request", request);
-}
+//     printf("CHRIS api call");
+//     CURL *curl = curl_easy_init();
+//     curl_easy_setopt(curl, CURLOPT_URL, 
+//         "https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products");
+//     curl_easy_perform(curl);
+//     sentry_value_t request = sentry_value_new_object();
+//     sentry_value_set_by_key(request, "url", sentry_value_new_string("https://application-monitoring-flask-dot-sales-engineering-sf.appspot.com/products"));
+//     sentry_value_set_by_key(request, "method", sentry_value_new_string("GET"));
+//     sentry_set_context("request", request);
+// }
 
 void startup(void)
 {

--- a/src/example.c
+++ b/src/example.c
@@ -20,6 +20,9 @@ void initialize_memory(char *mem)
 
 void api_call(void)
 {
+    // struct curl_slist *chunk = NULL;
+    // chunk = curl_slist_append(chunk, "sentry-trace: "); //Need to retrieve and interpolate the current trace-id?
+
     printf("CHRIS api call");
     CURL *curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, 
@@ -118,7 +121,7 @@ int main(int argc, char *argv[])
     sleep(2);
 
     sentry_span_t *child_filewrite = sentry_transaction_start_child(
-        async, 
+        tx, 
         "file.write", 
         "file write 1"
     );
@@ -142,7 +145,8 @@ int main(int argc, char *argv[])
         "call api endpoint"
     );
 
-    api_call();
+    // api_call();
+    sleep(2);
     sentry_span_finish(call_endpoint);
 
     sentry_span_t *grandchild_network_request_2 = sentry_transaction_start_child(
@@ -156,14 +160,13 @@ int main(int argc, char *argv[])
     sentry_span_finish(child_filewrite);
     sentry_span_finish(async);
 
+    // sentry_span_t *async2 = sentry_transaction_start_child(
+    //     tx, 
+    //     "http.async", 
+    //     "async operation 2"
+    // );
 
-    sentry_span_t *async2 = sentry_transaction_start_child(
-        tx, 
-        "http.async", 
-        "async operation 2"
-    );
-
-    sleep(2);
+    // sleep(2);
 
     sentry_span_t *fileread = sentry_transaction_start_child(
         tx, 


### PR DESCRIPTION
- Instrument performance for demo per the official [sentry-native SDK example.c file](https://github.com/getsentry/sentry-native/blob/master/examples/example.c)
- To trigger a transaction, run `make bin/example run_message`
- [Example transaction](https://sentry.io/organizations/testorg-az/performance/native:f4399f46ba8f428ba2b28de47a8a3059/?project=1720457&query=transaction.duration%3A%3C15m&statsPeriod=7d&transaction=renderscreen&unselectedSeries=p100%28%29) triggered in project `native`
- There was a real API call made to flask's `/products` endpoint, but I commented it out since setting it up requires downloading and configuring openssl and libcurl, and we don't want to have to do that in a time-sensitive situation. 

<img width="1786" alt="Screen Shot 2022-04-01 at 2 22 52 PM" src="https://user-images.githubusercontent.com/12092849/161343062-d09e57c4-4d40-4c25-82a8-afa4e41a7253.png">

